### PR TITLE
Add placeholder product website

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -13,8 +13,8 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "Solar System",
-  description: "Realtime API demo",
+  title: "FutureTech",
+  description: "Modern product showcase",
   icons: {
     icon: "/icon.png",
   },

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,18 @@
-import App from "@/components/app";
+import ProductCard from "@/components/ProductCard";
+import { products } from "@/lib/products";
 
-export default function Main() {
+export default function Home() {
   return (
-    <div className="relative size-full">
-      <App />
-    </div>
+    <main className="max-w-6xl mx-auto p-6">
+      <section className="text-center py-20">
+        <h1 className="text-5xl font-bold mb-4">FutureTech</h1>
+        <p className="text-lg text-gray-500">Innovative products for everyday life.</p>
+      </section>
+      <section className="grid gap-8 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+        {products.map((product) => (
+          <ProductCard key={product.id} product={product} />
+        ))}
+      </section>
+    </main>
   );
 }

--- a/app/product/[id]/page.tsx
+++ b/app/product/[id]/page.tsx
@@ -1,0 +1,19 @@
+import { products } from "@/lib/products";
+import Image from "next/image";
+import Link from "next/link";
+
+export default function ProductPage({ params }: { params: { id: string } }) {
+  const product = products.find((p) => p.id === params.id);
+  if (!product) return <div className="p-6">Product not found.</div>;
+  return (
+    <main className="max-w-3xl mx-auto p-6">
+      <Link href="/" className="text-blue-600 hover:underline">&larr; Back</Link>
+      <div className="relative h-80 w-full mt-4 mb-6">
+        <Image src={product.image} alt={product.name} fill className="object-cover rounded" />
+      </div>
+      <h2 className="text-4xl font-bold mb-2">{product.name}</h2>
+      <p className="text-gray-500 mb-4">{product.price}</p>
+      <p>{product.description}</p>
+    </main>
+  );
+}

--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -1,0 +1,20 @@
+"use client";
+import Image from "next/image";
+import Link from "next/link";
+import { Product } from "@/lib/products";
+
+export default function ProductCard({ product }: { product: Product }) {
+  return (
+    <Link href={`/product/${product.id}`}
+      className="block rounded-lg overflow-hidden shadow hover:shadow-xl transition-shadow duration-300">
+      <div className="relative h-64 w-full">
+        <Image src={product.image} alt={product.name} fill className="object-cover" />
+      </div>
+      <div className="p-4 bg-background">
+        <h3 className="text-xl font-semibold mb-1">{product.name}</h3>
+        <p className="text-sm text-gray-500 mb-2">{product.price}</p>
+        <p className="text-sm text-foreground/80">{product.description}</p>
+      </div>
+    </Link>
+  );
+}

--- a/lib/products.ts
+++ b/lib/products.ts
@@ -1,0 +1,31 @@
+export type Product = {
+  id: string;
+  name: string;
+  description: string;
+  image: string;
+  price: string;
+};
+
+export const products: Product[] = [
+  {
+    id: "phone",
+    name: "SmartPhone X",
+    description: "A sleek phone with edge-to-edge display and powerful processor.",
+    image: "https://source.unsplash.com/random/400x400?phone",
+    price: "$999",
+  },
+  {
+    id: "laptop",
+    name: "Laptop Pro",
+    description: "Lightweight laptop with stunning Retina display and long battery life.",
+    image: "https://source.unsplash.com/random/400x400?laptop",
+    price: "$1999",
+  },
+  {
+    id: "tablet",
+    name: "Tablet Air",
+    description: "Thin tablet perfect for work and play with incredible performance.",
+    image: "https://source.unsplash.com/random/400x400?tablet",
+    price: "$799",
+  },
+];


### PR DESCRIPTION
## Summary
- switch to "FutureTech" metadata
- create product list and dynamic product pages
- add product card component
- seed sample product data

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685ec0e001208321bda4607cb499bf70